### PR TITLE
fix single non-ASCII character

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -77,7 +77,7 @@
 #
 #   [*supervisor_environment*]
 #     A list of key/value pairs in the form KEY=val,KEY2=val2 that will be
-#     placed in the supervisord process’ environment.
+#     placed in the supervisord process environment.
 #     Default: undef
 #
 #   [*identifier*]


### PR DESCRIPTION
Similiar to https://github.com/example42/puppet-puppet/pull/56

More info 
https://projects.puppetlabs.com/issues/20897
https://tickets.puppetlabs.com/browse/PUP-1386

Error:
```
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: invalid byte sequence in US-ASCII at /etc/puppet/modules/supervisor/manifests/init.pp:1 on node test
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run
```