### PR TITLE
Empty string evaluates to true

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -88,7 +88,7 @@ define supervisor::service (
     require => Class['supervisor'],
   }
 
-  if $config_file {
+  if $config_file != '' {
     file { "${supervisor::params::conf_dir}/${name}.conf":
       ensure  => $config_ensure,
       source  => $config_file,


### PR DESCRIPTION
An empty string is evaluated as `true` in Puppet - https://docs.puppetlabs.com/puppet/latest/reference/lang_data_boolean.html#automatic-conversion-to-boolean